### PR TITLE
fix the creation of the temp file, holding all included configs for apache.

### DIFF
--- a/default/serverspec/apache_spec.rb
+++ b/default/serverspec/apache_spec.rb
@@ -51,7 +51,7 @@ end
 # temporarily combine config-files and remove spaces
 describe 'Combining configfiles' do
 
-  describe command(%Q(cat #{apache_config} > #{tmp_config}; for i in `egrep '^\\s*Include' #{apache_config} | awk '{ print $2}' | sed "s/['\\"]//g"`; do [ $(ls -A $i) ]  && cat $i >> #{tmp_config} || echo no files in $i ; done;)) do
+  describe command(%(cat #{apache_config} > #{tmp_config}; for i in `egrep '^\\s*Include' #{apache_config} | awk '{ print $2}' | sed "s/['\\"]//g"`; do [ $(ls -A $i) ]  && cat $i >> #{tmp_config} || echo no files in $i ; done;)) do
     its(:exit_status) { should eq 0 }
   end
 


### PR DESCRIPTION
this now works with no-quote,single-quote, and double-quote

TelekomLabs-DCO-1.1-Signed-off-by: Edmund Haselwanter me@ehaselwanter.com
(github: ehaselwanter)
