### PR TITLE
Remove non utf-8 characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 **/.tmp
 Gemfile.lock
 Berksfile.lock
+inspec.lock
 nbproject

--- a/controls/apache_spec.rb
+++ b/controls/apache_spec.rb
@@ -165,7 +165,7 @@ end
 control 'apache-09' do
   impact 1.0
   title 'Disable TRACE-methods'
-  desc 'The web server doesn’t allow TRACE request and help in blocking Cross Site Tracing attack.'
+  desc 'The web server doesn\'t allow TRACE request and help in blocking Cross Site Tracing attack.'
 
   describe file(File.join(apache.conf_dir, '/conf-enabled/security.conf')) do
     its('content') { should match(/^\s*?TraceEnable\s+?Off/) }
@@ -194,7 +194,7 @@ end
 
 control 'apache-11' do
   impact 1.0
-  title 'Disable Apache’s follows Symbolic Links for directories in alias.conf'
+  title 'Disable Apache\'s follows Symbolic Links for directories in alias.conf'
   desc 'Should include -FollowSymLinks or +SymLinksIfOwnerMatch for directories in alias.conf'
 
   describe file(File.join(apache.conf_dir, '/mods-enabled/alias.conf')) do


### PR DESCRIPTION
Using:
```
$ inspec version
3.0.52
```

With master now:
```
$ inspec exec https://github.com/dev-sec/apache-baseline/archive/master.tar.gz -t docker://cc_pg --reporter json-automate

/usr/local/lib/ruby/gems/2.4.0/gems/inspec-3.0.52/lib/inspec/reporters/json_automate.rb:13:in `encode': "\xE2" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
	from /usr/local/lib/ruby/gems/2.4.0/gems/inspec-3.0.52/lib/inspec/reporters/json_automate.rb:13:in `to_json'
	from /usr/local/lib/ruby/gems/2.4.0/gems/inspec-3.0.52/lib/inspec/reporters/json_automate.rb:13:in `render'
	from /usr/local/lib/ruby/gems/2.4.0/gems/inspec-3.0.52/lib/inspec/reporters.rb:39:in `render'
	from /usr/local/lib/ruby/gems/2.4.0/gems/inspec-3.0.52/lib/inspec/runner.rb:118:in `block in render_output'
	from /usr/local/lib/ruby/gems/2.4.0/gems/inspec-3.0.52/lib/inspec/runner.rb:117:in `each'
	from /usr/local/lib/ruby/gems/2.4.0/gems/inspec-3.0.52/lib/inspec/runner.rb:117:in `render_output'
	from /usr/local/lib/ruby/gems/2.4.0/gems/inspec-3.0.52/lib/inspec/runner.rb:142:in `run_tests'
	from /usr/local/lib/ruby/gems/2.4.0/gems/inspec-3.0.52/lib/inspec/runner.rb:111:in `run'
	from /usr/local/lib/ruby/gems/2.4.0/gems/inspec-3.0.52/lib/inspec/cli.rb:245:in `exec'
	from /usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
	from /usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
	from /usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
	from /usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
	from /usr/local/lib/ruby/gems/2.4.0/gems/inspec-3.0.52/bin/inspec:12:in `<top (required)>'
	from /usr/local/bin/inspec:23:in `load'
	from /usr/local/bin/inspec:23:in `<main>'
```

With this change:
```
$ inspec exec https://github.com/dev-sec/apache-baseline/archive/ff4664c22f9fc90224dadb77ae16b3e9bf9065ab.tar.gz -t docker://cc_pg --reporter json-automate

{"platform":{"name":"debian","release":"9.5"},"profiles": ...
```