### PR TITLE
Add apache library from core inspec as it was deprecated in inspec 4

### DIFF
--- a/libraries/apache.rb
+++ b/libraries/apache.rb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+# copyright: 2015, Vulcano Security GmbH
+
+class Apache < Inspec.resource(1)
+  name 'apache'
+  supports platform: 'unix'
+  desc 'Use the apache InSpec audit resource to retrieve Apache environment settings.'
+  example <<~EXAMPLE
+    describe apache do
+      its ('service') { should cmp 'apache2' }
+    end
+
+    describe apache do
+      its ('conf_dir') { should cmp '/etc/apache2' }
+    end
+
+    describe apache do
+      its ('conf_path') { should cmp '/etc/apache2/apache2.conf' }
+    end
+
+    describe apache do
+      its ('user') { should cmp 'www-data' }
+    end
+  EXAMPLE
+
+  attr_reader :service, :conf_dir, :conf_path, :user
+  def initialize
+    if inspec.os.debian?
+      @service = 'apache2'
+      @conf_dir = '/etc/apache2/'
+      @conf_path = File.join @conf_dir, 'apache2.conf'
+      @user = 'www-data'
+    else
+      @service = 'httpd'
+      @conf_dir = '/etc/httpd/'
+      @conf_path = File.join @conf_dir, '/conf/httpd.conf'
+      @user = 'apache'
+    end
+  end
+
+  def to_s
+    'Apache Environment'
+  end
+end

--- a/libraries/apache.rb
+++ b/libraries/apache.rb
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 # copyright: 2015, Vulcano Security GmbH
 
 class Apache < Inspec.resource(1)


### PR DESCRIPTION
The `apache` resource used by this profile has been deprecated in InSpec 4

```
$ inspec version
4.3.2

$ inspec exec https://github.com/dev-sec/apache-baseline/archive/master.tar.gz
[2019-05-07T10:25:06+01:00] ERROR: DEPRECATION: The apache resource is deprecated This resource was removed in InSpec 4.0. (used at apache-baseline-master/controls/apache_spec.rb:25)

$ echo $?
3
```

In this PR, I copied the resource from InSpec and removed the deprecation call from `initialize`.

If this gets merged, is it ok to bump the profile version to 2.1.0 and release it?