### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,23 @@
 # Change Log
 
-## [2.0.2](https://github.com/hardening-io/tests-apache-hardening/tree/2.0.2) (2017-05-08)
-[Full Changelog](https://github.com/hardening-io/tests-apache-hardening/compare/2.0.1...2.0.2)
+## [2.1.0](https://github.com/dev-sec/apache-baseline/tree/2.1.0) (2019-05-07)
+[Full Changelog](https://github.com/dev-sec/apache-baseline/compare/2.0.2...2.1.0)
+
+**Closed issues:**
+
+- Change the parameter from apache to httpd [\#28](https://github.com/dev-sec/apache-baseline/issues/28)
+
+**Merged pull requests:**
+
+- Add apache library from core inspec as it was deprecated in inspec 4 [\#30](https://github.com/dev-sec/apache-baseline/pull/30) ([alexpop](https://github.com/alexpop))
+- Fixed the issue related issues/28 [\#29](https://github.com/dev-sec/apache-baseline/pull/29) ([gadilasr](https://github.com/gadilasr))
+- Remove non utf-8 characters [\#27](https://github.com/dev-sec/apache-baseline/pull/27) ([alexpop](https://github.com/alexpop))
+- Update gems and ruby version to 2.4.1 [\#25](https://github.com/dev-sec/apache-baseline/pull/25) ([szEvEz](https://github.com/szEvEz))
+- Update issue templates [\#24](https://github.com/dev-sec/apache-baseline/pull/24) ([rndmh3ro](https://github.com/rndmh3ro))
+- use recommended spdx license identifier [\#23](https://github.com/dev-sec/apache-baseline/pull/23) ([chris-rock](https://github.com/chris-rock))
+
+## [2.0.2](https://github.com/dev-sec/apache-baseline/tree/2.0.2) (2017-05-08)
+[Full Changelog](https://github.com/dev-sec/apache-baseline/compare/2.0.1...2.0.2)
 
 **Merged pull requests:**
 
@@ -9,22 +25,22 @@
 - restrict ruby testing to version 2.3.3 und update gemfile [\#21](https://github.com/dev-sec/apache-baseline/pull/21) ([atomic111](https://github.com/atomic111))
 - Update profile version [\#20](https://github.com/dev-sec/apache-baseline/pull/20) ([alexpop](https://github.com/alexpop))
 
-## [2.0.1](https://github.com/hardening-io/tests-apache-hardening/tree/2.0.1) (2017-02-27)
-[Full Changelog](https://github.com/hardening-io/tests-apache-hardening/compare/2.0.0...2.0.1)
+## [2.0.1](https://github.com/dev-sec/apache-baseline/tree/2.0.1) (2017-02-27)
+[Full Changelog](https://github.com/dev-sec/apache-baseline/compare/2.0.0...2.0.1)
 
 **Merged pull requests:**
 
 - update common files [\#19](https://github.com/dev-sec/apache-baseline/pull/19) ([atomic111](https://github.com/atomic111))
 - Switch to the new apache-baseline name everywhere [\#18](https://github.com/dev-sec/apache-baseline/pull/18) ([alexpop](https://github.com/alexpop))
 
-## [2.0.0](https://github.com/hardening-io/tests-apache-hardening/tree/2.0.0) (2016-06-17)
-[Full Changelog](https://github.com/hardening-io/tests-apache-hardening/compare/1.0.0...2.0.0)
+## [2.0.0](https://github.com/dev-sec/apache-baseline/tree/2.0.0) (2016-06-17)
+[Full Changelog](https://github.com/dev-sec/apache-baseline/compare/1.0.0...2.0.0)
 
 **Merged pull requests:**
 
 - migrate to inspec profile [\#17](https://github.com/dev-sec/apache-baseline/pull/17) ([atomic111](https://github.com/atomic111))
 
-## [1.0.0](https://github.com/hardening-io/tests-apache-hardening/tree/1.0.0) (2015-10-15)
+## [1.0.0](https://github.com/dev-sec/apache-baseline/tree/1.0.0) (2015-10-15)
 **Merged pull requests:**
 
 - adapt to new robocop style [\#16](https://github.com/dev-sec/apache-baseline/pull/16) ([chris-rock](https://github.com/chris-rock))

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 gem 'highline', '~> 2.0.1'
 gem 'inspec', '~> 4'
-gem 'inspec-bin'
 gem 'rack', '2.0.6'
 gem 'rake'
 gem 'rubocop', '~> 0.66.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,13 @@
 
 source 'https://rubygems.org'
 
-gem 'highline', '~> 1.7.0'
-gem 'inspec', '~> 3.0.0'
-gem 'rack', '1.6.4'
+gem 'highline', '~> 2.0.1'
+gem 'inspec', '~> 4'
+gem 'inspec-bin'
+gem 'rack', '2.0.6'
 gem 'rake'
-gem 'rubocop', '~> 0.60.0'
+gem 'rubocop', '~> 0.66.0'
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.14.0'
+  gem 'github_changelog_generator'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'highline', '~> 2.0.2'
-gem 'inspec', '~> 4'
+gem 'inspec', '~> 3'
 gem 'rack', '~> 2.0.7'
 gem 'rake', '~> 12.3.2'
 gem 'rubocop', '~> 0.68.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,13 @@
 
 source 'https://rubygems.org'
 
-gem 'highline', '~> 2.0.1'
+gem 'highline', '~> 2.0.2'
 gem 'inspec', '~> 4'
-gem 'rack', '2.0.6'
-gem 'rake'
-gem 'rubocop', '~> 0.66.0'
+gem 'rack', '~> 2.0.7'
+gem 'rake', '~> 12.3.2'
+gem 'rubocop', '~> 0.68.1'
 
 group :tools do
-  gem 'github_changelog_generator'
+  gem 'github_changelog_generator', '~> 1.14.3'
+  gem 'pry-coolline', '~> 0.2.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -20,8 +20,10 @@ task default: [:lint, 'test:check']
 namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
-    dir = File.join(File.dirname(__FILE__))
-    system({ 'CHEF_LICENSE' => 'accept' }, "bundle exec inspec check #{dir}")
+    require 'inspec'
+    puts "Checking profile with InSpec Version: #{Inspec::VERSION}"
+    profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
+    pp profile.check
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
     dir = File.join(File.dirname(__FILE__))
-    sh("bundle exec inspec check #{dir}")
+    system({ 'CHEF_LICENSE' => 'accept' }, "bundle exec inspec check #{dir}")
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -27,18 +27,23 @@ namespace :test do
   end
 end
 
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed. By default its picking up the version from
-# inspec.yml. You can override that behavior with s`rake changelog to=1.2.0`
-begin
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts "Generate changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
+task :changelog do
+  # Automatically generate a changelog for this project. Only loaded if
+  # the necessary gem is installed. By default its picking up the version from
+  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
+  begin
+    require 'yaml'
+    metadata = YAML.load_file('inspec.yml')
+    v = ENV['to'] || metadata['version']
+    puts " * Generating changelog for version #{v}"
+    require 'github_changelog_generator/task'
+    GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+      config.future_release = v
+      config.user = 'dev-sec'
+      config.project = 'apache-baseline'
+    end
+    Rake::Task[:changelog].execute
+  rescue LoadError
+    puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
   end
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,6 +5,6 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
 summary: Test-suite for best-practice apache hardening
-version: 2.0.2
+version: 2.1.0
 supports:
   - os-family: unix


### PR DESCRIPTION
I bumped the version, but I don't seem to get CHANGELOG to update:

```
$ bundle exec rake
Generate changelog for version 2.1.0
```